### PR TITLE
Make matplotlib work in headless mode

### DIFF
--- a/stack_plot.py
+++ b/stack_plot.py
@@ -15,6 +15,10 @@
 # limitations under the License.
 
 import sys, seaborn, dateutil.parser, numpy, json, argparse
+
+import matplotlib
+matplotlib.use('Agg')
+
 from matplotlib import pyplot
 
 parser = argparse.ArgumentParser(description='Plot stack plot')

--- a/survival_plot.py
+++ b/survival_plot.py
@@ -15,6 +15,10 @@
 # limitations under the License.
 
 import sys, seaborn, dateutil.parser, numpy, json, collections, math, scipy.optimize, argparse, os
+
+import matplotlib
+matplotlib.use('Agg')
+
 from matplotlib import pyplot
 
 parser = argparse.ArgumentParser(description='Plot survival plot')


### PR DESCRIPTION
When running the script on a server without X, matplotlib must use `Agg`

http://matplotlib.org/faq/howto_faq.html#generate-images-without-having-a-window-appear