### PR TITLE
Use dict.get() to avoid missing key error

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -84,11 +84,7 @@ def get_file_histogram(commit, path):
     h = {}
     try:
         for old_commit, lines in repo.blame(commit, path):
-            try:
-                if old_commit.hexsha in commit2cohort:
-                    cohort = commit2cohort[old_commit.hexsha]
-            except:
-                traceback.print_exc()
+            cohort = commit2cohort.get(old_commit.hexsha, "MISSING")
             h[cohort] = h.get(cohort, 0) + len(lines)
 
             if old_commit.hexsha in commit2timestamp:


### PR DESCRIPTION
This PR is a follow-up to #29.

The root cause of the KeyError is: 

- the indexing the dict `commit2cohort` using [], and
- when using [] to index into the dict, a KeyError is thrown whenever `commit_old.hexsha` is not found in the dict `commit2cohort

By using the default `get` method for dict, a missing key will use `commit_old.hexsha` when found in the dict; otherwise, it will set to "MISSING"