### PR TITLE
Fix headless mode

### DIFF
--- a/stack_plot.py
+++ b/stack_plot.py
@@ -14,10 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys, seaborn, dateutil.parser, numpy, json, argparse
-
 import matplotlib
 matplotlib.use('Agg')
+
+import sys, seaborn, dateutil.parser, numpy, json, argparse
 
 from matplotlib import pyplot
 

--- a/survival_plot.py
+++ b/survival_plot.py
@@ -14,10 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys, seaborn, dateutil.parser, numpy, json, collections, math, scipy.optimize, argparse, os
-
 import matplotlib
 matplotlib.use('Agg')
+
+import sys, seaborn, dateutil.parser, numpy, json, collections, math, scipy.optimize, argparse, os
 
 from matplotlib import pyplot
 


### PR DESCRIPTION
Headless mode isn't working anymore, maybe because `seaborn` is importing `matplotlib` too

Fixup for #28 