### PR TITLE
Fix issue with new matplotlib version (#66)

### DIFF
--- a/git_of_theseus/stack_plot.py
+++ b/git_of_theseus/stack_plot.py
@@ -45,15 +45,15 @@ def stack_plot(input_fn, display=False, outfile='stack_plot.png', max_n=20, norm
         labels = data['labels']
     if normalize:
         y = 100. * numpy.array(y) / numpy.sum(y, axis=0)
-    pyplot.figure(figsize=(13, 8))
+    fig, ax = pyplot.subplots(figsize=(13, 8))
     pyplot.style.use('ggplot')
     ts = [dateutil.parser.parse(t) for t in data['ts']]
     colors = generate_n_colors(len(labels))
     if dont_stack:
         for color, label, series in zip(colors, labels, y):
-            pyplot.plot(ts, series, color=color, label=label, linewidth=2)
+            ax.plot(ts, series, color=color, label=label, linewidth=2)
     else:
-        pyplot.stackplot(ts, numpy.array(y), labels=labels, colors=colors)
+        ax.stackplot(ts, y, labels=labels, colors=colors)
     pyplot.legend(loc=2)
     if normalize:
         pyplot.ylabel('Share of lines of code (%)')


### PR DESCRIPTION
To be honest, I have no idea why this works - but looking at the [example](https://matplotlib.org/examples/pylab_examples/stackplot_demo.html), this is how you would create a stackplot - operating on an axis, not using a function from the `pyplot` namespace directly.

However it creates a new issue with the x axis label, which could potentially be fixed with a custom formatter... so this is not a ready-to-go solution - ideas and improvements welcome.

![image](https://user-images.githubusercontent.com/19366641/46198435-c19b3b80-c30c-11e8-8417-b4559704362d.png)
