### PR TITLE
Refactor with multiprocessing

### DIFF
--- a/git_of_theseus/analyze.py
+++ b/git_of_theseus/analyze.py
@@ -14,9 +14,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
-import argparse, git, datetime, numpy, pygments.lexers, traceback, time, os, fnmatch, json, progressbar, sys
+import argparse
+import datetime
+import git
+import json
+import multiprocessing
+import os
+import pygments.lexers
 import warnings
+
+from tqdm import tqdm
+from wcmatch import fnmatch
 
 # Some filetypes in Pygments are not necessarily computer code, but configuration/documentation. Let's not include those.
 IGNORE_PYGMENTS_FILETYPES = ['*.json', '*.md', '*.ps', '*.eps', '*.txt', '*.xml', '*.xsl', '*.rss', '*.xslt', '*.xsd', '*.wsdl', '*.wsf', '*.yaml', '*.yml']
@@ -26,154 +34,226 @@ for _, _, filetypes, _ in pygments.lexers.get_all_lexers():
     default_filetypes.update(filetypes)
 default_filetypes.difference_update(IGNORE_PYGMENTS_FILETYPES)
 
-c = chr if sys.version_info[0] >= 3 else unichr
-widget_kwargs = dict(samples=10000)
+
+class BlameProc(multiprocessing.Process):
+    def __init__(self, repo_dir, q, ret_q, blame_kwargs, commit2cohort, commit2timestamp):
+        super().__init__(daemon=True)
+        self.repo: git.Repo = git.Repo(repo_dir)
+        self.q: multiprocessing.Queue = q
+        self.ret_q: multiprocessing.Queue = ret_q
+        self.blame_kwargs = dict(blame_kwargs)
+        self.commit2cohort = dict(commit2cohort)
+        self.commit2timestamp = dict(commit2timestamp)
+
+    # Get Blame data for a `file` at `commit`
+    def get_file_histogram(self, path, blame):
+        h = {}
+        for old_commit, lines in blame:
+            cohort = self.commit2cohort.get(old_commit.hexsha, "MISSING")
+            _, ext = os.path.splitext(path)
+            keys = [('cohort', cohort), ('ext', ext), ('author', old_commit.author.name)]
+
+            if old_commit.hexsha in self.commit2timestamp:
+                keys.append(('sha', old_commit.hexsha))
+
+            for key in keys:
+                h[key] = h.get(key, 0) + len(lines)
+
+        return h
+
+    def run(self):
+        try:
+            while True:
+                entry, commit = self.q.get()
+                self.ret_q.put((entry, self.get_file_histogram(entry, self.repo.blame(commit, entry, **self.blame_kwargs))))
+        except:
+            pass
 
 
-def analyze(repo, cohortfm='%Y', interval=7*24*60*60, ignore=[], only=[], outdir='.', branch='master', all_filetypes=False, ignore_whitespace=False):
-    repo = git.Repo(repo)
+class BlameDriver:
+    def __init__(self, repo_dir, proc_count, last_file_y, cur_y, blame_kwargs, commit2cohort, commit2timestamp, quiet):
+        self.repo_dir = repo_dir
+        self.q = multiprocessing.Queue()
+        self.ret_q = multiprocessing.Queue()
+        self.last_file_y = last_file_y
+        self.cur_y = cur_y
+        self.proc_pool = []
+        if not quiet:
+            print('Starting up processes: ', end='')
+        for i in range(proc_count):
+            self.proc_pool.append(BlameProc(repo_dir, self.q, self.ret_q, blame_kwargs, commit2cohort, commit2timestamp))
+            self.proc_pool[i].start()
+            if not quiet:
+                print(i if i == 0 else ', ' + str(i), end='\n' if i == proc_count - 1 else '')
+
+    def fetch(self, commit, check_entries, bar):
+        processed_entries = 0
+        total_entries = len(check_entries)
+
+        for entry in check_entries:
+            self.q.put((entry.path, commit.hexsha))
+
+        while processed_entries < total_entries:
+            path, file_y = self.ret_q.get()
+
+            for key_tuple, file_locs in file_y.items():
+                self.cur_y[key_tuple] = self.cur_y.get(key_tuple, 0) + file_locs
+            self.last_file_y[path] = file_y
+            processed_entries += 1
+            bar.update()
+
+        return self.cur_y
+
+
+def analyze(repo_dir, cohortfm='%Y', interval=7 * 24 * 60 * 60, ignore=[], only=[], outdir='.', branch='master',
+            all_filetypes=False, ignore_whitespace=False, procs=2, quiet=False, opt=False):
+    repo = git.Repo(repo_dir)
+    blame_kwargs = {}
+    if ignore_whitespace:
+        blame_kwargs['w'] = True
+    master_commits = []  # only stores a subset
     commit2cohort = {}
-    code_commits = [] # only stores a subset
-    master_commits = []
     commit2timestamp = {}
-    curves_set = set()
+    curve_key_tuples = set()  # Keys of each curve that will be tracked
+    tqdm_args = {
+        'smoothing': 0.025,  # Exponential smoothing is still rather jumpy, a tiny number will do
+        'disable': quiet
+    }
     if not os.path.exists(outdir):
         os.makedirs(outdir)
 
+    # Check if specified branch exists
     try:
-        repo.git.checkout(branch)
-    except repo.exc.GitCommandError:
+        repo.git.show_ref('refs/heads/{:s}'.format(branch), verify=True)
+    except git.exc.GitCommandError:
         default_branch = repo.active_branch.name
-        warnings.warn("Requested branch: '{}' does not exist. Falling back to default branch: '{}'".format(branch, default_branch))
+        warnings.warn("Requested branch: '{:s}' does not exist. Falling back to default branch: '{:s}'".format(branch, default_branch))
 
         branch = default_branch
 
-    print('Listing all commits')
-    with progressbar.ProgressBar(max_value=progressbar.UnknownLength, widget_kwargs=widget_kwargs) as bar:
-        for i, commit in enumerate(repo.iter_commits(branch)):
-            bar.update(i)
-            cohort = datetime.datetime.utcfromtimestamp(commit.committed_date).strftime(cohortfm)
-            commit2cohort[commit.hexsha] = cohort
-            curves_set.add(('cohort', cohort))
-            curves_set.add(('author', commit.author.name))
-            if len(commit.parents) == 1:
-                code_commits.append(commit)
-                last_date = commit.committed_date
-                commit2timestamp[commit.hexsha] = commit.committed_date
+    if not quiet and repo.git.version_info < (2, 31, 0):
+        print('Old Git version {:d}.{:d}.{:d} detected. There are optimizations available in version 2.31.0 which speed up performance'.format(*repo.git.version_info))
 
-    print('Backtracking the master branch')
-    with progressbar.ProgressBar(max_value=progressbar.UnknownLength, widget_kwargs=widget_kwargs) as bar:
-        i, commit = 0, repo.head.commit
+    if opt:
+        if not quiet:
+            print('Generating git commit-graph... If you wish, this file is deletable later at .git/objects/info')
+        repo.git.execute(['git', 'commit-graph', 'write', '--changed-paths'])  # repo.git.commit_graph('write --changed-paths') doesn't work for some reason
+
+    desc = '{:<55s}'.format('Listing all commits')
+    for commit in tqdm(repo.iter_commits(branch), desc=desc, unit=' Commits', **tqdm_args):
+        cohort = datetime.datetime.utcfromtimestamp(commit.committed_date).strftime(cohortfm)
+        commit2cohort[commit.hexsha] = cohort
+        curve_key_tuples.add(('cohort', cohort))
+        curve_key_tuples.add(('author', commit.author.name))
+        commit2timestamp[commit.hexsha] = commit.committed_date
+
+    desc = '{:<55s}'.format('Backtracking the master branch')
+    with tqdm(desc=desc, unit=' Commits', **tqdm_args) as bar:
+        commit = repo.head.commit
         last_date = None
         while True:
-            bar.update(i)
-            if not commit.parents:
-                break
             if last_date is None or commit.committed_date < last_date - interval:
                 master_commits.append(commit)
                 last_date = commit.committed_date
-            i, commit = i+1, commit.parents[0]
+            bar.update()
+            if not commit.parents:
+                break
+            commit = commit.parents[0]
 
-    ok_entry_paths = {}
+    def_ft_str = '+({:s})'.format('|'.join(default_filetypes))
+    path_match_str = '{:s}|!+({:s})'.format('|'.join(only), '|'.join(ignore))
+    path_match_zero = len(only) == 0 and len(ignore) == 0
+    ok_entry_paths = dict()
+    entry_cache = {}
 
     def entry_path_ok(path):
         # All this matching is slow so let's cache it
         if path not in ok_entry_paths:
             ok_entry_paths[path] = (
-                (all_filetypes or any(fnmatch.fnmatch(os.path.split(path)[-1], filetype) for filetype in default_filetypes))\
-                and all([fnmatch.fnmatch(path, pattern) for pattern in only])\
-                and not any([fnmatch.fnmatch(path, pattern) for pattern in ignore]))
+                    (all_filetypes or fnmatch.fnmatch(os.path.split(path)[-1], def_ft_str, flags=fnmatch.EXTMATCH))
+                    and (path_match_zero or fnmatch.fnmatch(path, path_match_str, flags=fnmatch.NEGATE | fnmatch.EXTMATCH | fnmatch.SPLIT))
+            )
         return ok_entry_paths[path]
 
     def get_entries(commit):
-        return [entry for entry in commit.tree.traverse()
-                if entry.type == 'blob' and entry_path_ok(entry.path)]
+        if commit.hexsha not in entry_cache:
+            entry_cache[commit.hexsha] = [entry for entry in commit.tree.traverse() if entry.type == 'blob' and entry_path_ok(entry.path)]
+        return entry_cache[commit.hexsha]
 
     def get_top_dir(path):
         return os.path.dirname(path).split(os.sep)[0] + os.sep
 
-    print('Counting total entries to analyze + caching filenames')
+    master_commits = master_commits[::-1]  # Reverse it so it's chnological ascending
     entries_total = 0
-    with progressbar.ProgressBar(max_value=len(master_commits), widget_kwargs=widget_kwargs) as bar:
-        for i, commit in enumerate(reversed(master_commits)):
-            bar.update(i)
-            n = 0
+    desc = '{:<55s}'.format('Discovering entries & caching filenames')
+    with tqdm(desc='{:<55s}'.format('Entries Discovered'), unit=' Entries', position=1, **tqdm_args) as bar:
+        for commit in tqdm(master_commits, desc=desc, unit=' Commits', position=0, **tqdm_args):
             for entry in get_entries(commit):
-                n += 1
+                entries_total += 1
                 _, ext = os.path.splitext(entry.path)
-                curves_set.add(('ext', ext))
-                curves_set.add(('dir', get_top_dir(entry.path)))
-            entries_total += n
+                curve_key_tuples.add(('ext', ext))
+                curve_key_tuples.add(('dir', get_top_dir(entry.path)))
+                bar.update()
 
-    def get_file_histogram(commit, path):
-        h = {}
-        try:
-            blame_kwargs = {}
-            if ignore_whitespace:
-                blame_kwargs['w'] = True
-            for old_commit, lines in repo.blame(commit, path, **blame_kwargs):
-                cohort = commit2cohort.get(old_commit.hexsha, "MISSING")
-                _, ext = os.path.splitext(path)
-                keys = [('cohort', cohort), ('ext', ext), ('author', old_commit.author.name), ('dir', get_top_dir(path))]
+    curves = {}  # multiple y axis, in the form key_tuple: Array[y-axis points]
+    ts = []  # x axis
+    last_file_y = {}  # Contributions of each individual file to each individual curve, when the file was last seen
+    cur_y = {}  # Sum of all contributions between files towards each individual curve
+    commit_history = {}  # How many lines of a commit (by SHA) still exist at a given time
+    last_file_hash = {}  # File SHAs when they were last seen
+    blamer = BlameDriver(repo_dir, procs, last_file_y, cur_y, blame_kwargs, commit2cohort, commit2timestamp, quiet)
 
-                if old_commit.hexsha in commit2timestamp:
-                    keys.append(('sha', old_commit.hexsha))
-
-                for key in keys:
-                    h[key] = h.get(key, 0) + len(lines)
-        except KeyboardInterrupt:
-            raise
-        except:
-            traceback.print_exc()
-        return h
-
-    curves = {}
-    ts = []
-    file_histograms = {}
-    last_commit = None
-    commit_history = {}
-
-    print('Analyzing commit history')
-    with progressbar.ProgressBar(max_value=entries_total, widget_kwargs=widget_kwargs) as bar:
-        entries_processed = 0
-        for commit in reversed(master_commits):
+    desc = '{:<55s}'.format('Analyzing commit history with {:d} processes'.format(procs))
+    with tqdm(desc='{:<55s}'.format('Entries Processed'), total=entries_total, unit=' Entries', position=1, **tqdm_args) as bar:
+        for commit in tqdm(master_commits, desc=desc, unit=' Commits', position=0, **tqdm_args):
             t = datetime.datetime.utcfromtimestamp(commit.committed_date)
-            ts.append(t)
-            changed_files = set()
-            for diff in commit.diff(last_commit):
-                if diff.a_blob:
-                    changed_files.add(diff.a_blob.path)
-                if diff.b_blob:
-                    changed_files.add(diff.b_blob.path)
-            last_commit = commit
+            ts.append(t)  # x axis
 
-            histogram = {}
+            # START: Fast diff, to reduce no. of files checked via blame.
+            # File hashes are checked against previous iteration
             entries = get_entries(commit)
+
+            check_entries = []
+            cur_file_hash = {}
             for entry in entries:
-                bar.update(entries_processed)
-                entries_processed += 1
-                if entry.path in changed_files or entry.path not in file_histograms:
-                    file_histograms[entry.path] = get_file_histogram(commit, entry.path)
-                for key, count in file_histograms[entry.path].items():
-                    histogram[key] = histogram.get(key, 0) + count
+                cur_file_hash[entry.path] = entry.binsha
+                if entry.path in last_file_hash:
+                    if last_file_hash[entry.path] != entry.binsha:  # Modified file
+                        for key_tuple, count in last_file_y[entry.path].items():
+                            cur_y[key_tuple] -= count
+                        check_entries.append(entry)
+                    else:  # Identical file
+                        bar.update()
+                    del last_file_hash[entry.path]  # Identical/Modified file deleted, leaving deleted behind
+                else:  # Newly added file
+                    check_entries.append(entry)
+            for deleted_path in last_file_hash.keys():  # Deleted files
+                for key_tuple, count in last_file_y[deleted_path].items():
+                    cur_y[key_tuple] -= count
+            last_file_hash = cur_file_hash
+            # END: Fast diff
 
-            for key, count in histogram.items():
-                key_type, key_item = key
-                if key_type == 'sha':
-                    commit_history.setdefault(key_item, []).append((commit.committed_date, count))
+            # Multiprocess blame checker, updates cur_y
+            blamer.fetch(commit, check_entries, bar)
 
-            for key in curves_set:
-                curves.setdefault(key, []).append(histogram.get(key, 0))
+            for key_tuple, count in cur_y.items():
+                key_category, key = key_tuple
+                if key_category == 'sha':
+                    commit_history.setdefault(key, []).append((commit.committed_date, count))
+
+            for key_tuple in curve_key_tuples:
+                curves.setdefault(key_tuple, []).append(cur_y.get(key_tuple, 0))
 
     def dump_json(output_fn, key_type, label_fmt=lambda x: x):
-        key_items = sorted(k for t, k in curves_set if t == key_type)
+        key_items = sorted(k for t, k in curve_key_tuples if t == key_type)
         fn = os.path.join(outdir, output_fn)
-        print('Writing %s data to %s' % (key_type, fn))
+        if not quiet:
+            print('Writing %s data to %s' % (key_type, fn))
         f = open(fn, 'w')
         json.dump({'y': [curves[(key_type, key_item)] for key_item in key_items],
                    'ts': [t.isoformat() for t in ts],
                    'labels': [label_fmt(key_item) for key_item in key_items]
-        }, f)
+                   }, f)
         f.close()
 
     # Dump accumulated stuff
@@ -185,7 +265,8 @@ def analyze(repo, cohortfm='%Y', interval=7*24*60*60, ignore=[], only=[], outdir
     # Dump survival data
     fn = os.path.join(outdir, 'survival.json')
     f = open(fn, 'w')
-    print('Writing survival data to %s' % fn)
+    if not quiet:
+        print('Writing survival data to %s' % fn)
     json.dump(commit_history, f)
     f.close()
 
@@ -193,17 +274,25 @@ def analyze(repo, cohortfm='%Y', interval=7*24*60*60, ignore=[], only=[], outdir
 def analyze_cmdline():
     parser = argparse.ArgumentParser(description='Analyze git repo')
     parser.add_argument('--cohortfm', default='%Y', type=str, help='A Python datetime format string such as "%%Y" for creating cohorts (default: %(default)s)')
-    parser.add_argument('--interval', default=7*24*60*60, type=int, help='Min difference between commits to analyze (default: %(default)s)')
+    parser.add_argument('--interval', default=7 * 24 * 60 * 60, type=int, help='Min difference between commits to analyze (default: %(default)ss)')
     parser.add_argument('--ignore', default=[], action='append', help='File patterns that should be ignored (can provide multiple, will each subtract independently)')
-    parser.add_argument('--only', default=[], action='append', help='File patterns that have to match (can provide multiple, will all have to match)')
+    parser.add_argument('--only', default=[], action='append', help='File patterns that can match (can provide multiple, will match any one)')
     parser.add_argument('--outdir', default='.', help='Output directory to store results (default: %(default)s)')
     parser.add_argument('--branch', default='master', type=str, help='Branch to track (default: %(default)s)')
     parser.add_argument('--ignore-whitespace', default=[], action='store_true', help='Ignore whitespace changes when running git blame.')
     parser.add_argument('--all-filetypes', action='store_true', help='Include all files (if not set then will only analyze %s' % ','.join(default_filetypes))
-    parser.add_argument('repo')
+    parser.add_argument('--quiet', action='store_true', help='Disable all console output (default: %(default)s)')
+    parser.add_argument('--procs', default=2, type=int, help='Number of processes to use. There is a point of diminishing returns (default: %(default)s)')
+    parser.add_argument('--opt', action='store_true', help='Generates git commit-graph; Improves performance at the cost of some (~80KB/kCommit) disk space (default: %(default)s)')
+    parser.add_argument('repo_dir')
     kwargs = vars(parser.parse_args())
 
-    analyze(**kwargs)
+    try:
+        analyze(**kwargs)
+    except KeyboardInterrupt:
+        exit(1)
+    except:
+        raise
 
 
 if __name__ == '__main__':

--- a/git_of_theseus/stack_plot.py
+++ b/git_of_theseus/stack_plot.py
@@ -45,7 +45,7 @@ def stack_plot(input_fn, display=False, outfile='stack_plot.png', max_n=20, norm
         labels = data['labels']
     if normalize:
         y = 100. * numpy.array(y) / numpy.sum(y, axis=0)
-    pyplot.figure(figsize=(13, 8))
+    pyplot.figure(figsize=(16, 12), dpi=120)
     pyplot.style.use('ggplot')
     ts = [dateutil.parser.parse(t) for t in data['ts']]
     colors = generate_n_colors(len(labels))

--- a/setup.py
+++ b/setup.py
@@ -10,12 +10,13 @@ setup(name='git-of-theseus',
       install_requires=[
           'gitpython',
           'numpy',
-          'progressbar2',
+          'tqdm',
+          'wcmatch',
           'pygments',
           'matplotlib',
           'scipy',
       ],
-      entry_points = {
+      entry_points={
         'console_scripts': [
           'git-of-theseus-analyze=git_of_theseus.analyze:analyze_cmdline',
           'git-of-theseus-survival-plot=git_of_theseus:survival_plot_cmdline',


### PR DESCRIPTION
It was running a tad slow for my liking, so added in multiprocessing & changed out some implementations. 


Core logic is essentially the same, though I did change the behavior of multiple `--only` flags from 'AND' to 'OR', otherwise there'd need to be a loop to match each pattern sequentially. I don't really see a use case where the user can't just convert an 'AND' only to an 'OR' only, so I think it should be fine? 

#### Other changes
- Added `--quiet`, which suppresses all console output. Should close #53 , and idk why #51 is still up
- Added `--opt` which makes git generate a commit-graph, which speeds up git blame by ~20-40% in my tests
- Added `--procs` which specifies how many Python processes to run (and in turn how many git processes are run)
- Gave `stack_plot.py` more pixels
- Switched from `progressbar2` to `tqdm` (Has iterations/s) and from `fnmatch` to `wcmatch.fnmatch` (faster, by a lot)
- Stopped `analyze` from trying to check out a branch to check if it exists
- Added/updated some pics

I do believe the minimum python requirement is 3.6 with this PR, though I only tested on 3.9

#### Performance
- Entry discovery is now ~5-10x faster
- Analyzing is now *at least* 2x faster, depending on how many processes is configured
- node/src took ~50 minutes on the old code, ~9 minutes with 12 processes (With maxing out my hexa core 5820k)
- tensorflow took 2 or 3 hours
- rust was about 3 hours
- git's about 30 minutes

#### Random Windows weirdness
- Windows defender doesn't quite like having so many git/python processes running and eats some CPU; Turning it off makes it faster, but if anyone knows how to stop defender from doing this in the first place, would love to hear

