### PR TITLE
Execute check_mailmap if a .mailmap file exists in the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Rust – stack plot:
 Plotting other stuff
 --------------------
 
-`git-of-theseus-analyze` will write `exts.json`, `cohorts.json` and `authors.json`. You can run `git-of-theseus-stack-plot authors.json` to plot author statistics as well, or `git-of-theseus-stack-plot exts.json` to plot file extension statistics. For author statistics, you might want to create a [.mailmap](https://git-scm.com/docs/gitmailmap) file in the root directory of the repository to deduplicate authors. If you need to create a .mailmap file the following scripts can list the distinct author-email combinations in a repository:
+`git-of-theseus-analyze` will write `exts.json`, `cohorts.json` and `authors.json`. You can run `git-of-theseus-stack-plot authors.json` to plot author statistics as well, or `git-of-theseus-stack-plot exts.json` to plot file extension statistics. For author statistics, you might want to create a [.mailmap](https://git-scm.com/docs/gitmailmap) file in the root directory of the repository to deduplicate authors. If you need to create a .mailmap file the following command can list the distinct author-email combinations in a repository:
 
 Mac / Linux
 
@@ -78,7 +78,7 @@ git log --pretty=format:"%an %ae" | sort | uniq
 Windows Powershell
 
 ```powershell
-git log --pretty=format:"%an %ae" | Select-Object -Unique
+git log --pretty=format:"%an %ae" | Sort-Object | Select-Object -Unique
 ```
 
 For instance, here's the author statistics for [Kubernetes](https://github.com/kubernetes/kubernetes):

--- a/README.md
+++ b/README.md
@@ -67,7 +67,21 @@ Rust – stack plot:
 Plotting other stuff
 --------------------
 
-`git-of-theseus-analyze` will write `exts.json`, `cohorts.json` and `authors.json`. You can run `git-of-theseus-stack-plot authors.json` to plot author statistics as well, or `git-of-theseus-stack-plot exts.json` to plot file extension statistics. For author statistics, you might want to create a [.mailmap](https://git-scm.com/docs/git-check-mailmap) file to deduplicate authors. For instance, here's the author statistics for [Kubernetes](https://github.com/kubernetes/kubernetes):
+`git-of-theseus-analyze` will write `exts.json`, `cohorts.json` and `authors.json`. You can run `git-of-theseus-stack-plot authors.json` to plot author statistics as well, or `git-of-theseus-stack-plot exts.json` to plot file extension statistics. For author statistics, you might want to create a [.mailmap](https://git-scm.com/docs/gitmailmap) file in the root directory of the repository to deduplicate authors. If you need to create a .mailmap file the following scripts can list the distinct author-email combinations in a repository:
+
+Mac / Linux
+
+```shell
+git log --pretty=format:"%an %ae" | sort | uniq
+```
+
+Windows Powershell
+
+```powershell
+git log --pretty=format:"%an %ae" | Select-Object -Unique
+```
+
+For instance, here's the author statistics for [Kubernetes](https://github.com/kubernetes/kubernetes):
 
 ![git](https://raw.githubusercontent.com/erikbern/git-of-theseus/master/pics/git-kubernetes-authors.png)
 


### PR DESCRIPTION
This PR adds logic to check if a .mailmap file exists in the repo and execute check_mailmap on each contributor name and email if so - which should resolve [issue 47](https://github.com/erikbern/git-of-theseus/issues/47).

- I had a look at the [corresponding issue in the GitPython repo](https://github.com/gitpython-developers/GitPython/issues/764). My understanding is the presence of a .mailmap file shouldn't effect how author names and emails are read from commits or blames - [it only changes the output of some git log calls](https://lukasmestan.com/using-mailmap-in-git-repository/) - so I think even if that issue is fixed on GitPython - it wouldn't solve the issue here in git-of-theseus. Not automatically anyway - although the advice on that issue helped with this implementation.
- As suggested early in the comments on [issue 47](https://github.com/erikbern/git-of-theseus/issues/47) I used a .mailmap file but had to introduce an explicit call to  [check-mailmap](https://git-scm.com/docs/git-check-mailmap) file to map the original author username and email to the mapped name and email.
- Apologies for the code formatting pollution in this PR - I have Black/isort running on my home setup by default - if that's too distracting or annoying I'm happy to revert the unnecessary formatting changes.