### PR TITLE
Fix issue 86 drop Python 3.6 build and add Python 3.11 build

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -22,7 +22,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install package
-        run: pip install .
+        run: | 
+          pip install .
+          pip install scipy
 
       - name: Run tests
         run: |

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -10,14 +10,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     name: Tests on Python ${{ matrix.python-version }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/git_of_theseus/analyze.py
+++ b/git_of_theseus/analyze.py
@@ -544,7 +544,7 @@ def analyze(
     f.close()
 
 
-@functools.cache
+@functools.lru_cache(maxsize=None)
 def get_mailmap_author_name_email(repo, author_name, author_email):
     pre_mailmap_author_email = f"{author_name} <{author_email}>"
     mail_mapped_author_email: str = repo.git.check_mailmap(pre_mailmap_author_email)

--- a/git_of_theseus/survival_plot.py
+++ b/git_of_theseus/survival_plot.py
@@ -18,8 +18,14 @@ import matplotlib
 
 matplotlib.use("Agg")
 
-import sys, dateutil.parser, numpy, json, collections, math, argparse, os
+import argparse
+import collections
+import json
+import math
+import os
+import sys
 
+import numpy
 from matplotlib import pyplot
 
 
@@ -86,7 +92,10 @@ def survival_plot(
         return loss
 
     if exp_fit:
-        import scipy.optimize
+        try:
+            import scipy.optimize
+        except ImportError:
+            sys.exit("Scipy is a required dependency when using the --exp-fit flag")
 
         print("fitting exponential function")
         k = scipy.optimize.fmin(fit, 0.5, maxiter=50)[0]

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ setup(
         "wcmatch",
         "pygments",
         "matplotlib",
-        "scipy",
     ],
     entry_points={
         "console_scripts": [

--- a/setup.py
+++ b/setup.py
@@ -1,27 +1,28 @@
 from distutils.core import setup
-import setuptools
 
-setup(name='git-of-theseus',
-      version='0.3.3',
-      description='Plot stats on Git repositories',
-      author='Erik Bernhardsson',
-      author_email='mail@erikbern.com',
-      url='https://github.com/erikbern/git-of-theseus',
-      packages=['git_of_theseus'],
-      install_requires=[
-          'gitpython',
-          'numpy',
-          'tqdm',
-          'wcmatch',
-          'pygments',
-          'matplotlib',
-      ],
-      entry_points={
-        'console_scripts': [
-          'git-of-theseus-analyze=git_of_theseus.analyze:analyze_cmdline',
-          'git-of-theseus-survival-plot=git_of_theseus:survival_plot_cmdline',
-          'git-of-theseus-stack-plot=git_of_theseus:stack_plot_cmdline',
-          'git-of-theseus-line-plot=git_of_theseus:line_plot_cmdline',
-      ]
-  }
+setup(
+    name="git-of-theseus",
+    version="0.3.3",
+    description="Plot stats on Git repositories",
+    author="Erik Bernhardsson",
+    author_email="mail@erikbern.com",
+    url="https://github.com/erikbern/git-of-theseus",
+    packages=["git_of_theseus"],
+    install_requires=[
+        "gitpython",
+        "numpy",
+        "tqdm",
+        "wcmatch",
+        "pygments",
+        "matplotlib",
+        "scipy",
+    ],
+    entry_points={
+        "console_scripts": [
+            "git-of-theseus-analyze=git_of_theseus.analyze:analyze_cmdline",
+            "git-of-theseus-survival-plot=git_of_theseus:survival_plot_cmdline",
+            "git-of-theseus-stack-plot=git_of_theseus:stack_plot_cmdline",
+            "git-of-theseus-line-plot=git_of_theseus:line_plot_cmdline",
+        ]
+    },
 )


### PR DESCRIPTION
This is some random fixes to the build actions and fixed a regression I introduced in a previous PR (didn't realise functools.cache wasn't introduced until Python 3.9). Changes include:

- Drop Python 3.6 setup and add Python 3.11 setup
- Replace functools.cache with the functionally equivalent older format functools.lru_cache(maxsize=None) to be compatible with Python 3.7 upwards
- Added Scipy to CI install but kept it as an optional dependency (I'm assuming it is intended to be an optional dependency)