### PR TITLE
Fix sum calculation for other categories in stack plot

### DIFF
--- a/git_of_theseus/stack_plot.py
+++ b/git_of_theseus/stack_plot.py
@@ -31,7 +31,7 @@ def stack_plot(
     y = numpy.array(data["y"])
     if y.shape[0] > max_n:
         js = sorted(range(len(data["labels"])), key=lambda j: max(y[j]), reverse=True)
-        other_sum = numpy.sum(y[j] for j in js[max_n:])
+        other_sum = sum((y[j] for j in js[max_n:]), start=numpy.zeros_like(y[0]))
         top_js = sorted(js[:max_n], key=lambda j: data["labels"][j])
         y = numpy.array([y[j] for j in top_js] + [other_sum])
         labels = [data["labels"][j] for j in top_js] + ["other"]


### PR DESCRIPTION
It looks like numpy had deprecated passing in a generator to numpy.sum: https://numpy.org/devdocs/release/2.4.0-notes.html#numpy-array2string-and-numpy-sum-deprecations-finalized

So I've replaced numpy sum with a python-native sum. Also adding the start parameter to ensure the output has the correct size/shape for the 2d array.

Fair warning, I did use an LLM to do a lot of the analysis here, I couldn't find any contributors guide so figured I'd call that out here in case that was an issue. I did test this locally and it looks right to me.